### PR TITLE
Change link to point at new mailing list

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -69,7 +69,7 @@ The result?
 <div class="narrow-text-block">
 
 Find our code on [GitHub](https://github.com/operate-first), meet the community on [slack](https://join.slack.com/t/operatefirst/shared_invite/zt-o2gn4wn8-O39g7sthTAuPCvaCNRnLww), and join our mailing lists for announcements and discussions.
-* [General mailing list](https://listman.redhat.com/mailman/listinfo/operate-first) for Operate First users and contributors (a new mailing list is coming soon!)
+* [Community mailing list](https://lists.operate-first.cloud/admin/lists/community.lists.operate-first.cloud/) for Operate First users and contributors
 * OpenInfra labs [mailing list](http://lists.opendev.org/cgi-bin/mailman/listinfo/openinfralabs) for those interested in cloud operations more broadly
 
 </div>


### PR DESCRIPTION
This seems to be the only link in the site to the mailing list.